### PR TITLE
Added test for watch functionality

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -1229,3 +1229,38 @@ test.serial('should handle getting directories concurrently', async (t) => {
   }
 })
 
+test.serial('should handle watch', async (t) => {
+  if (process.env.TEST_USING_MOCKS) {
+    t.pass("n/a for mocks");
+    return;
+  }
+
+  const sleep = async (ms: number) => { return new Promise((resolve) => setTimeout(resolve, ms)); };
+  const rootHandle = await getRootHandle();
+  const smbHandle = rootHandle as SmbDirectoryHandle;
+  let caught: {path: string, action: string} = {path: "", action: ""};
+  smbHandle.watch(async (watchEvent) => {
+    if (!watchEvent || watchEvent.path !== "watch_event_file" || watchEvent.action !== "create") {
+      console.log("watch caught something unexpected:", watchEvent, new Date());
+    }
+    caught = watchEvent;
+  })
+
+  await sleep(500)
+    .then(async () => {
+      // console.log("post-sleep");
+      const rootHandleAlt = await getRootHandle();
+      // console.log("obtained root handle");
+      const fileHandle = await rootHandleAlt.getFileHandle("watch_event_file", {create: true});
+      // console.log("obtained file handle");
+      const writable = await fileHandle.createWritable();
+      // console.log("obtained writable");
+      const writer = await writable.getWriter();
+      // console.log("obtained writer");
+      await writer.write("eventful");
+      // console.log("finished writing");
+    });
+  // console.log("done watching", new Date());
+  t.deepEqual(caught, {path: "watch_event_file", action: "create"});
+})
+

--- a/deps.sh
+++ b/deps.sh
@@ -127,8 +127,8 @@ if [ "${OS}" == "Darwin" ]; then
             CFLAGS="-fPIC" \
             LDFLAGS="-framework GSS" \
             YACC="${YACC}"
-        make -j${PROCS} clean all
-        make install
+        make clean
+        make -j${PROCS} install
         popd
     fi
 


### PR DESCRIPTION
Also changed watch implementation to use a separate connection, to avoid having mutex be locked indefinately while a watch is in progress.

Seems to also fix weird behavior where watch callback would be called with info object that had garbled action element.

However, after running `yarn test` 60 times, only 40 runs were successful.

14 runs ended with:
node(47623,0x17012f000) malloc: *** error for object 0x1: pointer being freed was not allocated node(47623,0x17012f000) malloc: *** set a breakpoint in malloc_error_break to debug Stopping samba EXITCODE=129

4 runs ended with:
node(48547,0x174603000) malloc: Heap corruption detected, free list is damaged at 0x60000002b7e0 *** Incorrect guard value: 1
node(48547,0x174603000) malloc: *** set a breakpoint in malloc_error_break to debug Stopping samba EXITCODE=129

2 runs had no error messages and no 'should handle watch' - simply ended with: Stopping samba EXITCODE=129