### PR TITLE
Improved handling of smb2_file_notify_change_information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ export interface JsSmbCreateWritableOptions {
 export interface JsSmbNotifyChange {
   path: string
   action: string
+  fromPath?: string
 }
 export declare class JsSmbDirectoryHandleEntries {
   [Symbol.asyncIterator]: AsyncIterableIterator<[string, JsSmbDirectoryHandle | JsSmbFileHandle]>

--- a/src/smb/mod.rs
+++ b/src/smb/mod.rs
@@ -47,7 +47,7 @@ pub enum VFSWatchMode {
 }
 
 pub trait VFSNotifyChangeCallback {
-    fn call(&self, path: String, action: String);
+    fn call(&self, path: String, action: String, from_path: Option<String>);
 }
 
 pub struct NotifyChangeCallback {
@@ -55,8 +55,8 @@ pub struct NotifyChangeCallback {
 }
 
 impl SmbNotifyChangeCallback for NotifyChangeCallback {
-    fn call(&self, path: String, action: String) {
-        self.inner.call(path, action);
+    fn call(&self, path: String, action: String, from_path: Option<String>) {
+        self.inner.call(path, action, from_path);
     }
 }
 


### PR DESCRIPTION
Now converts linked list into vector first, changing RenamedOldName/RenamedNewName entries coming in pairs into a single notify change information entry that has the old name stored as `from_name`.
Watch callback now has from_name parameter of type Option<String>, in order to get old name specified as part of watch event for rename operation.